### PR TITLE
elm-format 0.7.0-exp incorrectly changes imports to make code not compile

### DIFF
--- a/src/Input/Number.elm
+++ b/src/Input/Number.elm
@@ -1,23 +1,28 @@
-module Input.Number exposing (Options, StringOptions, input, inputString, defaultOptions, defaultStringOptions)
+module Input.Number exposing (Options, StringOptions, defaultOptions, defaultStringOptions, input, inputString)
 
 {-| Number input
+
+
 # Options
+
 @docs StringOptions, Options, defaultStringOptions, defaultOptions
 
+
 # View
+
 @docs input, inputString
+
 -}
 
-import Html exposing (Attribute, Html)
-import Html.Attributes exposing (style, type_)
-import Html.Events exposing (onWithOptions, keyCode)
-import Html.Attributes as Attributes exposing (value)
 import Char
-import String
-import Json.Decode as Json
+import Html exposing (Attribute, Html)
+import Html.Attributes as Attributes exposing (style, type_, value, max, min)
+import Html.Events exposing (keyCode, onWithOptions)
 import Input.Decoder exposing (eventDecoder)
 import Input.KeyCode exposing (allowedKeyCodes)
+import Json.Decode as Json
 import Regex
+import String
 
 
 type alias GenericOptions options =
@@ -30,11 +35,12 @@ type alias GenericOptions options =
 
 {-| Options of the input component.
 
- * `maxLength` is the maximum number of character allowed in this input. Set to `Nothing` for no limit.
- * `maxValue` is the maximum number value allowed in this input. Set to `Nothing` for no limit.
- * `minValue` is the minimum number value allowed in this input. Set to `Nothing` for no limit.
- * `onInput` is the Msg tagger for the onInput event.
- * `hasFocus` is an optional Msg tagger for onFocus/onBlur event.
+  - `maxLength` is the maximum number of character allowed in this input. Set to `Nothing` for no limit.
+  - `maxValue` is the maximum number value allowed in this input. Set to `Nothing` for no limit.
+  - `minValue` is the minimum number value allowed in this input. Set to `Nothing` for no limit.
+  - `onInput` is the Msg tagger for the onInput event.
+  - `hasFocus` is an optional Msg tagger for onFocus/onBlur event.
+
 -}
 type alias Options msg =
     { maxLength : Maybe Int
@@ -47,11 +53,12 @@ type alias Options msg =
 
 {-| Options of the input component with `String` value.
 
- * `maxLength` is the maximum number of character allowed in this input. Set to `Nothing` for no limit.
- * `maxValue` is the maximum number value allowed in this input. Set to `Nothing` for no limit.
- * `minValue` is the minimum number value allowed in this input. Set to `Nothing` for no limit.
- * `onInput` is the Msg tagger for the onInput event.
- * `hasFocus` is an optional Msg tagger for onFocus/onBlur event.
+  - `maxLength` is the maximum number of character allowed in this input. Set to `Nothing` for no limit.
+  - `maxValue` is the maximum number value allowed in this input. Set to `Nothing` for no limit.
+  - `minValue` is the minimum number value allowed in this input. Set to `Nothing` for no limit.
+  - `onInput` is the Msg tagger for the onInput event.
+  - `hasFocus` is an optional Msg tagger for onFocus/onBlur event.
+
 -}
 type alias StringOptions msg =
     { maxLength : Maybe Int
@@ -64,7 +71,8 @@ type alias StringOptions msg =
 
 {-| Default value for `Options`.
 Params:
- * `onInput` (type: `Maybe Int -> msg`) : The onInput Msg tagger
+
+  - `onInput` (type: `Maybe Int -> msg`) : The onInput Msg tagger
 
 Value:
 
@@ -88,7 +96,8 @@ defaultOptions onInput =
 
 {-| Default options for input with `String` value
 Params:
- * `onInput` (type: `String -> msg`) : The onInput Msg tagger
+
+  - `onInput` (type: `String -> msg`) : The onInput Msg tagger
 
 Value:
 
@@ -154,35 +163,34 @@ input options attributes currentValue =
         maxAttribute =
             options.maxValue
                 |> Maybe.map toString
-                |> Maybe.map Html.Attributes.max
+                |> Maybe.map Attributes.max
                 |> Maybe.map toArray
                 |> Maybe.withDefault []
 
         minAttribute =
             options.minValue
                 |> Maybe.map toString
-                |> Maybe.map Html.Attributes.min
+                |> Maybe.map Attributes.min
                 |> Maybe.map toArray
                 |> Maybe.withDefault []
     in
-        Html.input
-            ((List.append attributes
-                [ currentValue
-                    |> Maybe.map toString
-                    |> Maybe.withDefault ""
-                    |> value
-                , onKeyDown options currentValue
-                , Html.Events.onInput (String.toInt >> Result.toMaybe >> options.onInput)
-                , onChange options
-                , type_ "number"
-                ]
-             )
-                |> List.append onFocusAttribute
-                |> List.append onBlurAttribute
-                |> List.append maxAttribute
-                |> List.append minAttribute
-            )
-            []
+    Html.input
+        (List.append attributes
+            [ currentValue
+                |> Maybe.map toString
+                |> Maybe.withDefault ""
+                |> value
+            , onKeyDown options currentValue
+            , Html.Events.onInput (String.toInt >> Result.toMaybe >> options.onInput)
+            , onChange options
+            , type_ "number"
+            ]
+            |> List.append onFocusAttribute
+            |> List.append onBlurAttribute
+            |> List.append maxAttribute
+            |> List.append minAttribute
+        )
+        []
 
 
 {-| View function for input with `String` value
@@ -229,33 +237,32 @@ inputString options attributes currentValue =
         maxAttribute =
             options.maxValue
                 |> Maybe.map toString
-                |> Maybe.map Html.Attributes.max
+                |> Maybe.map Attributes.max
                 |> Maybe.map toArray
                 |> Maybe.withDefault []
 
         minAttribute =
             options.minValue
                 |> Maybe.map toString
-                |> Maybe.map Html.Attributes.min
+                |> Maybe.map Attributes.min
                 |> Maybe.map toArray
                 |> Maybe.withDefault []
     in
-        Html.input
-            ((List.append attributes
-                [ currentValue
-                    |> value
-                , onKeyDownString options currentValue
-                , Html.Events.onInput options.onInput
-                , onChangeString options
-                , type_ "number"
-                ]
-             )
-                |> List.append onFocusAttribute
-                |> List.append onBlurAttribute
-                |> List.append maxAttribute
-                |> List.append minAttribute
-            )
-            []
+    Html.input
+        (List.append attributes
+            [ currentValue
+                |> value
+            , onKeyDownString options currentValue
+            , Html.Events.onInput options.onInput
+            , onChangeString options
+            , type_ "number"
+            ]
+            |> List.append onFocusAttribute
+            |> List.append onBlurAttribute
+            |> List.append maxAttribute
+            |> List.append minAttribute
+        )
+        []
 
 
 filterNonDigit : String -> String
@@ -290,7 +297,7 @@ onKeyDownString options currentValue =
                 <= 57
 
         filterKey =
-            (\event ->
+            \event ->
                 if event.ctrlKey || event.altKey || event.metaKey then
                     Json.fail "modifier key is pressed"
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
@@ -302,14 +309,13 @@ onKeyDownString options currentValue =
                     Json.fail "numeric"
                 else
                     Json.succeed event.keyCode
-            )
 
         decoder =
             eventDecoder
                 |> Json.andThen filterKey
                 |> Json.map (\_ -> options.onInput currentValue)
     in
-        onWithOptions "keydown" eventOptions decoder
+    onWithOptions "keydown" eventOptions decoder
 
 
 onKeyDown : Options msg -> Maybe Int -> Attribute msg
@@ -339,7 +345,7 @@ onKeyDown options currentValue =
                 <= 57
 
         filterKey =
-            (\event ->
+            \event ->
                 if event.ctrlKey || event.altKey || event.metaKey then
                     Json.fail "modifier key is pressed"
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
@@ -351,14 +357,13 @@ onKeyDown options currentValue =
                     Json.fail "numeric"
                 else
                     Json.succeed event.keyCode
-            )
 
         decoder =
             eventDecoder
                 |> Json.andThen filterKey
                 |> Json.map (\_ -> options.onInput currentValue)
     in
-        onWithOptions "keydown" eventOptions decoder
+    onWithOptions "keydown" eventOptions decoder
 
 
 isValid : String -> GenericOptions a -> Bool
@@ -369,8 +374,8 @@ isValid newValue options =
                 |> String.toInt
                 |> Result.toMaybe
     in
-        not (exceedMaxLength options.maxLength newValue)
-            && not (exceedMaxValue options.maxValue updatedNumber)
+    not (exceedMaxLength options.maxLength newValue)
+        && not (exceedMaxValue options.maxValue updatedNumber)
 
 
 onChange : Options msg -> Html.Attribute msg
@@ -395,7 +400,7 @@ onChange options =
                 |> checkWithMinValue
                 |> checkWithMaxValue
     in
-        Html.Events.on "change" (Json.map (toInt >> options.onInput) Html.Events.targetValue)
+    Html.Events.on "change" (Json.map (toInt >> options.onInput) Html.Events.targetValue)
 
 
 onChangeString : StringOptions msg -> Html.Attribute msg
@@ -431,7 +436,7 @@ onChangeString options =
                 |> toString
                 |> flip (++) (leadingZero string)
     in
-        Html.Events.on "change" (Json.map (options.onInput) Html.Events.targetValue)
+    Html.Events.on "change" (Json.map options.onInput Html.Events.targetValue)
 
 
 lessThanMinValue : Maybe Int -> Maybe Int -> Bool
@@ -451,6 +456,6 @@ exceedMaxValue maxValue number =
 exceedMaxLength : Maybe Int -> String -> Bool
 exceedMaxLength maxLength value =
     maxLength
-        |> Maybe.map (\maxLength -> maxLength >= (String.length value))
+        |> Maybe.map (\maxLength -> maxLength >= String.length value)
         |> Maybe.map not
         |> Maybe.withDefault False


### PR DESCRIPTION
So 0.7.0-exp will remove two imports in src/Input/Number.elm:
import Html.Attributes exposing (style, type_)
import Html.Attributes as Attributes exposing (value)

And replaces them with:
import Html.Attributes as Attributes exposing (value, style, type_)

Which stops the code compiling.

The answer is to have one import:
import Html.Attributes as Attributes exposing (value, style, type_, min, max)

And changing the code on lines 156, 163, 231 and 238 (that use min and max). 

This will survive 0.6.1-alpha and 0.7.0-exp reformatting.

My first commit is to show what 0.7.0 does and my second is to show the least change to the code (squash at will).