### PR TITLE
Keyboard text selection (shift+arrow keys) doesn't work with Elm 0.19

### DIFF
--- a/src/Input/BigNumber.elm
+++ b/src/Input/BigNumber.elm
@@ -140,7 +140,7 @@ onKeyDown options currentValue =
                     ( options.onInput currentValue, False )
 
                 else if event.shiftKey then
-                    ( options.onInput currentValue, True )
+                    ( options.onInput currentValue, False )
 
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
                     ( options.onInput currentValue, False )

--- a/src/Input/Float.elm
+++ b/src/Input/Float.elm
@@ -295,7 +295,7 @@ onKeyDownString options currentValue =
                     ( options.onInput currentValue, False )
 
                 else if event.shiftKey then
-                    ( options.onInput currentValue, True )
+                    ( options.onInput currentValue, False )
 
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
                     ( options.onInput currentValue, False )
@@ -346,7 +346,7 @@ onKeyDown options currentValue =
                     ( options.onInput currentValue, False )
 
                 else if event.shiftKey then
-                    ( options.onInput currentValue, True )
+                    ( options.onInput currentValue, False )
 
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
                     ( options.onInput currentValue, False )

--- a/src/Input/Number.elm
+++ b/src/Input/Number.elm
@@ -300,7 +300,7 @@ onKeyDownString options currentValue =
                     ( options.onInput currentValue, False )
 
                 else if event.shiftKey then
-                    ( options.onInput currentValue, True )
+                    ( options.onInput currentValue, False )
 
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
                     ( options.onInput currentValue, False )
@@ -348,7 +348,7 @@ onKeyDown options currentValue =
                     ( options.onInput currentValue, False )
 
                 else if event.shiftKey then
-                    ( options.onInput currentValue, True )
+                    ( options.onInput currentValue, False )
 
                 else if List.any ((==) event.keyCode) allowedKeyCodes then
                     ( options.onInput currentValue, False )


### PR DESCRIPTION
Keyboard-based text selection, i.e. using shift and the arrow keys) worked in Numeric inputs using Elm 0.18/5.2.1 (and, I assume also BigNumber and Float), but it does not work in 0.19/5.2.2. When pressing e.g. Shift+Left, nothing happens. This is because the code ends up calling preventDefault when shift is pressed. This seems deliberate (since handling of shift differs from ctrl/alt/meta), so maybe this breaks something else that I'm not noticing, but changing the code so that preventDefault isn't called fixes keyboard selection. 