### PR TITLE
[hotfix] Doubled Message Broadcast

### DIFF
--- a/src/Input/Number.elm
+++ b/src/Input/Number.elm
@@ -309,7 +309,7 @@ onKeyDownString options currentValue =
                     (isNumber event.keyCode || isNumPad event.keyCode)
                         && isValid (newValue event.keyCode) options
                 then
-                    ( options.onInput (newValue event.keyCode), False )
+                    ( options.onInput (newValue event.keyCode), True)
 
                 else
                     ( options.onInput currentValue, True )

--- a/src/Input/Number.elm
+++ b/src/Input/Number.elm
@@ -357,7 +357,7 @@ onKeyDown options currentValue =
                     (isNumber event.keyCode || isNumPad event.keyCode)
                         && isValid (newValue event.keyCode) options
                 then
-                    ( options.onInput (String.toInt <| newValue event.keyCode), False )
+                    ( options.onInput (String.toInt <| newValue event.keyCode), True)
 
                 else
                     ( options.onInput currentValue, True )


### PR DESCRIPTION
The input message is broadcasted multiple times, provoking undesired cross-browser behaviour. 

Steps to reproduce: 
- Go to the demo (preferably FF)
- Add a debug statement before the message broadcast (\w Debug.log)
- Press any key, other than aflanumeric
- Press a number
- Observe in the console the number of times it is called

Escalation: 
- On Firefox, at times, it duplicates the input

It solves:
- https://github.com/abadi199/elm-input-extra/issues/23