### PR TITLE
Add caps lock to the list of allowed key codes

### DIFF
--- a/src/Input/KeyCode.elm
+++ b/src/Input/KeyCode.elm
@@ -14,6 +14,7 @@ allowedKeyCodes =
     , tab
     , enter
     , shift
+    , capsLock
     ]
 
 
@@ -70,3 +71,8 @@ rightArrow =
 downArrow : Int
 downArrow =
     40
+
+
+capsLock : Int
+capsLock =
+    20


### PR DESCRIPTION
Fixes a bug that causes unexpected text input when pressing caps lock. 